### PR TITLE
Changing include of malloc(3) from <malloc.h> to <stdlib.h>

### DIFF
--- a/src/clc88.c
+++ b/src/clc88.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "emu.h"
 #include "frontend/frontend.h"
 #include "cpu.h"


### PR DESCRIPTION
To compile in both Linux and macOS.